### PR TITLE
Add pytest test for Custom_Scorer conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ Training data is prepared in Data Studio application with help of predictions, g
 2. To implement Entity Linker based on semantic links in sentences and the whole text.
 3. To implement storing results of NER to the local or cloud-based Database.
 
+## Running Tests
+Install pytest and run:
+
+```bash
+pytest
+```

--- a/tests/test_custom_scorer.py
+++ b/tests/test_custom_scorer.py
@@ -1,0 +1,38 @@
+import ast
+import types
+
+
+def load_custom_scorer_class():
+    with open('custom_scorer_2_copy.py', 'r', encoding='utf-8') as f:
+        source = f.read()
+    module_ast = ast.parse(source)
+    class_def = next(
+        node for node in module_ast.body if isinstance(node, ast.ClassDef) and node.name == 'Custom_Scorer'
+    )
+    module = types.ModuleType('temp_custom_scorer')
+    exec(compile(ast.Module([class_def], []), 'custom_scorer_2_copy.py', 'exec'), module.__dict__)
+    return module.Custom_Scorer
+
+
+Custom_Scorer = load_custom_scorer_class()
+
+
+def test_convert_to_spacy_format_simple():
+    sample_json = [
+        {
+            "text": "John loves Mary",
+            "label": [
+                {"start": 0, "end": 4, "labels": ["PERSON"]},
+                {"start": 11, "end": 15, "labels": ["PERSON"]},
+            ],
+        }
+    ]
+
+    scorer = Custom_Scorer.__new__(Custom_Scorer)
+    result = Custom_Scorer.convert_to_spacy_format(scorer, sample_json)
+    expected = [(
+        "John loves Mary",
+        {"entities": [(0, 4, "PERSON"), (11, 15, "PERSON")]},
+    )]
+
+    assert result == expected


### PR DESCRIPTION
## Summary
- add unit test for `Custom_Scorer.convert_to_spacy_format`
- make `tests` a package for pytest discovery
- document how to run pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f508e170c8332ab3d39031b913ab2