### PR TITLE
Fix missing check for matcher output

### DIFF
--- a/upl_8_copy.py
+++ b/upl_8_copy.py
@@ -164,10 +164,11 @@ def get_relation(sent):
   matcher.add("matching_1",[pattern]) 
 
   matches = matcher(doc)
+  if not matches:
+      return ""
   k = len(matches) - 1
-  
-  span = doc[matches[k][1]:matches[k][2]] 
-  
+  span = doc[matches[k][1]:matches[k][2]]
+
   return(span.text)
 
 # if len(doc) !=0:


### PR DESCRIPTION
## Summary
- ensure `get_relation` returns empty string when no pattern match is found

## Testing
- `python3 -m py_compile custom_scorer_2_copy.py preannotated_copy.py upl_8_copy.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4f0922048332acbdb70953776765